### PR TITLE
Update tests to work with proper line endings

### DIFF
--- a/test/Test/Markdownify/ConverterExtraTest.php
+++ b/test/Test/Markdownify/ConverterExtraTest.php
@@ -25,7 +25,7 @@ class ConverterExtraTest extends ConverterTestCase
     /**
      * @dataProvider providerHeadingConversion
      */
-    public function testHeadingConversion_withAttribute($level, $attributesHTML, $attributesMD)
+    public function testHeadingConversion_withAttribute($level, $attributesHTML, $attributesMD = null)
     {
         $innerHTML = 'Heading '.$level;
         $md = str_pad('', $level, '#').' '.$innerHTML.$attributesMD;

--- a/test/Test/Markdownify/ConverterTestCase.php
+++ b/test/Test/Markdownify/ConverterTestCase.php
@@ -22,14 +22,14 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider providerHeadingConversion
      */
-    public function testHeadingConversion_withAttribute($level, $attributesHTML)
+    public function testHeadingConversion_withAttribute($level, $attributesHTML, $attributesMD = null)
     {
         $innerHTML = 'Heading '.$level;
         if (empty($attributesHTML)) {
             $md = str_pad('', $level, '#').' '.$innerHTML;
         } else {
-            $md = '<h'.$level.$attributesHTML.'>'.PHP_EOL
-                .'  '.$innerHTML.PHP_EOL
+            $md = '<h'.$level.$attributesHTML.'>'."\n"
+                .'  '.$innerHTML."\n"
                 .'</h'.$level.'>';
         }
         $html = '<h'.$level.$attributesHTML.'>'.$innerHTML.'</h'.$level.'>';


### PR DESCRIPTION
Fixes a strict warning with ConvertExtraTest and fixes line endings.
