### PR TITLE
Use alternative italic character

### DIFF
--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -609,7 +609,7 @@ class Converter
      */
     protected function handleTag_em()
     {
-        $this->out('*', true);
+        $this->out('_', true);
     }
 
     protected function handleTag_i()

--- a/test/Test/Markdownify/ConverterTestCase.php
+++ b/test/Test/Markdownify/ConverterTestCase.php
@@ -399,7 +399,7 @@ This is [another example](http://example2.com/ "Title") inline link.';
         $data['strong-escape2']['html'] = '__double asterisks__';
         $data['strong-escape2']['md'] = '\_\_double asterisks\_\_';
         $data['em']['html'] = '<em>single asterisks</em>';
-        $data['em']['md'] = '*single asterisks*';
+        $data['em']['md'] = '_single asterisks_';
         $data['em-escape']['html'] = '*single asterisks*';
         $data['em-escape']['md'] = '\*single asterisks\*';
         $data['em-escape2']['html'] = '_single asterisks_';


### PR DESCRIPTION
This should prevent invalid markdown, for example:

    ***bold** italic*

The above is more difficult to convert to html, then the following:

    _**bold** italic_