### PR TITLE
Improved <br> and whitespace fix

### DIFF
--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -68,7 +68,7 @@ class Converter
 
     /**
      * position where the link reference will be displayed
-     * 
+     *
      *
      * @var int
      */
@@ -274,8 +274,6 @@ class Converter
      */
     public function parseString($html)
     {
-        $html = $this->prepareHtml($html);
-
         $this->parser->html = $html;
         $this->parse();
 
@@ -284,7 +282,7 @@ class Converter
 
     /**
      * set the position where the link reference will be displayed
-     * 
+     *
      * @param int $linkPosition
      * @return void
      */
@@ -348,8 +346,33 @@ class Converter
                         $this->handleTagToText();
                         continue;
                     }
+
+                    // block elements
                     if (!$this->parser->keepWhitespace && $this->parser->isBlockElement && $this->parser->isStartTag) {
                         $this->parser->html = ltrim($this->parser->html);
+                    }
+
+                    // inline elements
+                    if (!$this->parser->keepWhitespace && $this->parser->isInlineContext) {
+                        if ($this->parser->isStartTag) {
+                            // move spaces after the start element to before the element
+                            if (preg_match('~^(\s+)~', $this->parser->html, $matches)) {
+                                $this->out($matches[1]);
+                                $this->parser->html = ltrim($this->parser->html, " \t\0\x0B");
+                            }
+                        } else {
+                            if (!empty($this->buffer)) {
+                                $str =& $this->buffer[count($this->buffer) - 1];
+                            } else {
+                                $str =& $this->output;
+                            }
+
+                            // move spaces before the end element to after the element
+                            if (preg_match('~(\s+)$~', $str, $matches)) {
+                                $str = rtrim($this->output, " \t\0\x0B");
+                                $this->parser->html = $matches[1] . $this->parser->html;
+                            }
+                        }
                     }
                     if ($this->isMarkdownable()) {
                         if ($this->parser->isBlockElement && $this->parser->isStartTag && !$this->lastWasBlockTag && !empty($this->output)) {
@@ -795,7 +818,7 @@ class Converter
             //  [1]: mailto:mail@example.com Title
             $tag['href'] = 'mailto:' . $bufferDecoded;
         }
-        
+
         if ($this->linkPosition == self::LINK_IN_PARAGRAPH) {
             return '[' . $buffer . '](' . $this->getLinkReference($tag) . ')';
         }
@@ -861,7 +884,7 @@ class Converter
             $this->out($out, true);
             return ;
         }
-        
+
         // ![This image][id]
         $link_id = false;
         if (!empty($this->footnotes)) {
@@ -884,7 +907,7 @@ class Converter
             array_push($this->footnotes, $tag);
         }
         $out .= '[' . $link_id . ']';
-        
+
         $this->out($out, true);
     }
 
@@ -1133,7 +1156,7 @@ class Converter
      * buffers
      *
      * @param string $put
-     * @param boolean $nowrap 
+     * @param boolean $nowrap
      * @return void
      */
     protected function out($put, $nowrap = false)
@@ -1329,154 +1352,4 @@ class Converter
     {
         return end($this->parser->openTags);
     }
-
-    /**
-     * Helper method to prepare html for correct markdown parsing. This will correct BR tags inside other
-     * tags like EM or STRONG.
-     *
-     * For example:
-     *   <strong>Hello,<br>How are you doing?</strong>
-     * Will be corrected to
-     *   <strong>Hello,</strong><br><strong>How are you doing?</strong>
-     *
-     * @param \DOMDocument $dom
-     */
-    protected function fixBreaks(\DOMDocument $dom)
-    {
-        /** @var \DOMNode[] $brs */
-        $brs = $dom->getElementsByTagName('br');
-        $stopTags = array('body', 'p');
-
-        foreach ($brs as $br) {
-            if ($br->parentNode && !in_array($br->parentNode->tagName, $stopTags)) {
-                $parent = $br->parentNode;
-
-                /** @var \DOMNode[] $childNodes */
-                $childNodes   = $parent->childNodes;
-                $mainFragment = $dom->createDocumentFragment();
-                $fragment     = $dom->createDocumentFragment();
-
-                foreach ($childNodes as $childChild) {
-                    if ($childChild->nodeName !== 'br') {
-                        $fragment->appendChild($childChild->cloneNode(true));
-                    } else {
-                        if ($fragment->hasChildNodes()) {
-                            $newNode = $dom->createElement($parent->nodeName);
-                            $newNode->appendChild($fragment);
-
-                            $mainFragment->appendChild($newNode);
-
-                            // reset fragment
-                            $fragment = $dom->createDocumentFragment();
-                        }
-
-                        $mainFragment->appendChild($childChild->cloneNode(true));
-                    }
-                }
-
-                if ($fragment->hasChildNodes()) {
-                    $newNode = $dom->createElement($parent->nodeName);
-                    $newNode->appendChild($fragment);
-
-                    $mainFragment->appendChild($newNode);
-                }
-
-                $parent->parentNode->replaceChild($mainFragment, $parent);
-
-                $this->fixBreaks($dom);
-
-                break;
-            }
-        }
-    }
-
-    /**
-     * Helper method to prepare html for correct markdown parsing. This will correct spaces around tags.
-     * It will correct spaces at begin tag and end tag.
-     *
-     * For example:
-     *   <p>This is<strong> strong</strong> text</p>
-     * Will be corrected to
-     *   <p>This is <strong>strong</strong> text</p>
-     *
-     *
-     * @param \DOMDocument $dom
-     * @param string       $tagName
-     */
-    protected function fixTagSpaces(\DOMDocument $dom, $tagName)
-    {
-        $elements = $dom->getElementsByTagName($tagName);
-
-        /** @var \DOMNode $element */
-        foreach ($elements as $element) {
-            if ($element->firstChild && $element->firstChild instanceof \DOMText && $element->firstChild->wholeText[0] === ' ') {
-                $element->replaceChild(new \DOMText(ltrim($element->firstChild->wholeText, ' ')), $element->firstChild);
-                $element->parentNode->insertBefore($dom->createTextNode(' '), $element);
-            }
-
-            if ($element->lastChild && $element->lastChild instanceof \DOMText && substr($element->lastChild->wholeText, -1) === ' ') {
-                $element->replaceChild(new \DOMText(rtrim($element->lastChild->wholeText, ' ')), $element->lastChild);
-                if ($element->nextSibling) {
-                    $element->nextSibling->parentNode->insertBefore($dom->createTextNode(' '), $element->nextSibling);
-                } else {
-                    $element->parentNode->appendChild($dom->createTextNode(' '));
-                }
-            }
-        }
-    }
-
-    /**
-     * Returns inner html from a dom document node
-     *
-     * @param \DOMDocument $dom
-     * @param \DOMNode     $node
-     *
-     * @return string
-     */
-    protected function getInnerHtml(\DOMDocument $dom, \DOMNode $node)
-    {
-        $innerHtml = '';
-
-        foreach ($node->childNodes as $child) {
-            $innerHtml .= $dom->saveXML($child);
-        }
-
-        return $innerHtml;
-    }
-
-    /**
-     * Applies some fixes so we can better parse the html
-     *
-     * @param string $html
-     *
-     * @return string
-     */
-    protected function prepareHtml($html)
-    {
-        $dom = new \DOMDocument();
-        $dom->substituteEntities = false;
-
-        // extra mb_convert_encoding pass http://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly?answertab=active#tab-top
-        // in some environments the meta charset is not enough
-        $dom->loadHTML(
-            mb_convert_encoding(
-                '<html><head><meta charset="utf-8"></head><body>' . $html . '</body></html>',
-                'HTML-ENTITIES',
-                'UTF-8'
-            )
-        );
-
-        $this->fixBreaks($dom);
-        $this->fixTagSpaces($dom, 'em');
-        $this->fixTagSpaces($dom, 'strong');
-        $this->fixTagSpaces($dom, 'b');
-        $this->fixTagSpaces($dom, 'i');
-
-        $body = $dom->getElementsByTagName('body');
-        $preparedHtml = $this->getInnerHtml($dom, $body->item(0));
-
-        return $preparedHtml;
-    }
-
-
 }

--- a/test/Test/Markdownify/ConverterTestCase.php
+++ b/test/Test/Markdownify/ConverterTestCase.php
@@ -84,7 +84,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
         return array(
             array('AT&amp;T', 'AT&T'),
             array('4 &lt; 5', '4 < 5'),
-            array('&copy;', '©')
+            array('&copy;', '&copy;')
         );
     }
 
@@ -450,7 +450,9 @@ This is [another example](http://example2.com/ "Title") inline link.';
     {
         $data = array();
         $data['break1']['html'] = "<strong>Hello,<br>How are you doing?</strong>";
-        $data['break1']['md'] = "**Hello,**  \n**How are you doing?**";
+        $data['break1']['md'] = "**Hello,  \nHow are you doing?**";
+        $data['break2']['html'] = "<b>Hey,<br> How you're doing?</b><br><br><b>Sorry<br><br> You can't get through</b>";
+        $data['break2']['md'] = "**Hey,   \nHow you're doing?**  \n  \n**Sorry  \n   \nYou can't get through**";
 
         return $data;
     }
@@ -472,10 +474,10 @@ This is [another example](http://example2.com/ "Title") inline link.';
         $data = array();
         $data['strong']['html'] = "<p>This is<strong> strong</strong> text</p>";
         $data['strong']['md'] = "This is **strong** text";
-        $data['em']['html'] = "<p>This is<em> italic </em> text</p>";
+        $data['em']['html'] = "<p>This is<em> italic </em>text</p>";
         $data['em']['md'] = "This is _italic_ text";
-        $data['b']['html'] = "<p>Not bold, <b> bold</b></p>";
-        $data['b']['md'] = "Not bold, **bold**";
+        $data['b']['html'] = "<p>Not bold,<b> bolder    </b>boldst</p>";
+        $data['b']['md'] = "Not bold, **bolder** boldst";
         $data['i']['html'] = "<p>Not italic, <i>italic </i></p>";
         $data['i']['md'] = "Not italic, _italic_";
 


### PR DESCRIPTION
### TL;DR

This fixes #12 in a different, less destructive way.

### Longer version 

By putting the html through the `DOMDocument` class, a lot of changes are made to it, which in turn can lead to different Markdown, especially when the html is invalid in all sorts of ways (which is rather common on the web, ask browser vendors :wink: ).

In my case I had html that didn't properly close tags:

```html
<b>header<b><br>
Some text
<br><br>

<b>Another header
<br><br>
Some more text
```

Which before resulted in the following Markdown:

```md
**header**
Some text

**Another header**

Some more text

```

Now it does something like this:

```md
**header**
Some text

****Another header****

Some more text

```

This keeps on growing on each header. Now, of course the html is wrong, but I still think the resulting Markdown should represent what you'd see if you loaded that html [in a web browser][1]:

```md
**header
Some text**

**Another header**

Some more text

```

[1]: http://codepen.io/anon/pen/pvBvgy

This is also according to the CommonMark spec, which allows for a single newline in inline elements ([test][2]), but not for 2 ([test][3])

[2]: http://spec.commonmark.org/dingus/?text=*foo%20%20%0Abar*%0A
[3]: http://spec.commonmark.org/dingus/?text=*foo%0A%0Abar*%0A

I've updated the `parse()` method to fix both problems in #12, while adhering to the rules explained above. This is also updated in the test suite (which by the way could really use a rewrite that doesn't rely on trailing spaces, since many editors/IDE's trim those).