### PR TITLE
Fixed issue with missing keys

### DIFF
--- a/src/Markdownify/ConverterExtra.php
+++ b/src/Markdownify/ConverterExtra.php
@@ -270,7 +270,7 @@ class ConverterExtra extends Converter
             // finally build the table in Markdown Extra syntax
             $separator = array();
             if (!isset($this->table['aligns'])) {
-                $this->table['aligns'] = [];
+                $this->table['aligns'] = array();
             }
             // seperator with correct align identifikators
             foreach ($this->table['aligns'] as $col => $align) {

--- a/src/Markdownify/ConverterExtra.php
+++ b/src/Markdownify/ConverterExtra.php
@@ -269,6 +269,9 @@ class ConverterExtra extends Converter
         } else {
             // finally build the table in Markdown Extra syntax
             $separator = array();
+            if (!isset($this->table['aligns'])) {
+                $this->table['aligns'] = [];
+            }
             // seperator with correct align identifikators
             foreach ($this->table['aligns'] as $col => $align) {
                 if (!$this->keepHTML && !isset($this->table['col_widths'][$col])) {
@@ -367,6 +370,9 @@ class ConverterExtra extends Converter
             $this->buffer();
         } else {
             $buffer = trim($this->unbuffer());
+            if (!isset($this->table['col_widths'][$this->col])) {
+                $this->table['col_widths'][$this->col] = 0;
+            }
             $this->table['col_widths'][$this->col] = max($this->table['col_widths'][$this->col], $this->strlen($buffer));
             $this->table['rows'][$this->row][$this->col] = $buffer;
         }


### PR DESCRIPTION
Upon trying to render a table within a table, there seems to be an issue with certain keys not being set, triggering an undefined index error.

For example, using the following HTML:
```html
<table>
  <tr>
    <td>
      <table>
        <tr>
          <td>
            Hello World!
          </td>
        </tr>
      </table>   
    </td>
  </tr>
</table>
```

The following error is triggered when calling `parseString($html)`:

```
Undefined index: col_widths

/project/vendor/pixel418/markdownify/src/Markdownify/ConverterExtra.php:370
/project/vendor/pixel418/markdownify/src/Markdownify/Converter.php:372
/project/vendor/pixel418/markdownify/src/Markdownify/Converter.php:278
/project/vendor/pixel418/markdownify/src/Markdownify/ConverterExtra.php:518
```

Trying to debug the issue, I added a line to automatically add the key if it was missing:
```php
if (!isset($this->table['col_widths'][$this->col])) {
    $this->table['col_widths'][$this->col] = 0;
}
```

Then another error popped up:
```
Undefined index: aligns

/project/vendor/pixel418/markdownify/src/Markdownify/ConverterExtra.php:273
/project/vendor/pixel418/markdownify/src/Markdownify/Converter.php:372
/project/vendor/pixel418/markdownify/src/Markdownify/Converter.php:278
/project/vendor/pixel418/markdownify/src/Markdownify/ConverterExtra.php:521
```

Fixing it in the same way (see diff), I did not get any more errors and the table seemed to be rendered properly. However I'm pretty sure this is not a proper fix, the real issue is that your table parsing is not accounting for multi-dimensional tables. 

Can you confirm this is indeed an issue?