### PR TITLE
Update Converter to return markdown anchor tags

### DIFF
--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -787,15 +787,17 @@ class Converter
 
         if ($buffer == $tag['href'] && empty($tag['title'])) {
             // <http://example.com>
-            return '<' . $buffer . '>';
+            //return '<' . $buffer . '>';
+            return '[' . $buffer . '](' . $buffer . ')';
         }
 
         $bufferDecoded = $this->decode(trim($buffer));
         if (substr($tag['href'], 0, 7) == 'mailto:' && 'mailto:' . $bufferDecoded == $tag['href']) {
-            if (is_null($tag['title'])) {
-                // <mail@example.com>
-                return '<' . $bufferDecoded . '>';
-            }
+            // if (is_null($tag['title'])) {
+            //     // <mail@example.com>
+            //     return '<' . $bufferDecoded . '>';
+            // }
+            
             // [mail@example.com][1]
             // ...
             //  [1]: mailto:mail@example.com Title


### PR DESCRIPTION
Update Converter to not return non-markdown anchor tags.

On anchor tags with a url as the text value for the link such as: 
`<a href="https://test.com">https://test.com</a>`

This converter library would return
`<test.com>`
Which is not valid markdown.