### PR TITLE
Added resetState function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5.5"
+    },
     "autoload": {
         "psr-0": {
             "Markdownify": "src",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-0": {

--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -270,14 +270,11 @@ class Converter
      * parse a HTML string
      *
      * @param string $html
-     * @param bool $resetState set to true to reset buffers and indents
      * @return string markdown formatted
      */
-    public function parseString($html, $resetState = false)
+    public function parseString($html)
     {
-        if ($resetState) {
-            $this->resetState();
-        }
+        $this->resetState();
 
         $this->parser->html = $html;
         $this->parse();

--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -270,9 +270,10 @@ class Converter
      * parse a HTML string
      *
      * @param string $html
+     * @param bool $resetState set to true to reset buffers and indents
      * @return string markdown formatted
      */
-    public function parseString($html, $resetState = true)
+    public function parseString($html, $resetState = false)
     {
         if ($resetState) {
             $this->resetState();

--- a/src/Markdownify/Converter.php
+++ b/src/Markdownify/Converter.php
@@ -272,8 +272,12 @@ class Converter
      * @param string $html
      * @return string markdown formatted
      */
-    public function parseString($html)
+    public function parseString($html, $resetState = true)
     {
+        if ($resetState) {
+            $this->resetState();
+        }
+
         $this->parser->html = $html;
         $this->parse();
 
@@ -1377,5 +1381,22 @@ class Converter
                 $this->parser->html = $matches[1] . $this->parser->html;
             }
         }
+    }
+
+    /**
+     * Resetting the state forces the instance to behave as a fresh instance.
+     * Ideal for running within a loop where you want to maintain a single instance.
+     */
+    protected function resetState()
+    {
+        $this->notConverted = array();
+        $this->skipConversion = false;
+        $this->buffer = array();
+        $this->indent = '';
+        $this->stack = array();
+        $this->lineBreaks = 0;
+        $this->lastClosedTag = '';
+        $this->lastWasBlockTag = false;
+        $this->footnotes = array();
     }
 }

--- a/src/Markdownify/ConverterExtra.php
+++ b/src/Markdownify/ConverterExtra.php
@@ -497,10 +497,9 @@ class ConverterExtra extends Converter
      * parse a HTML string, clean up footnotes prior
      *
      * @param string $HTML input
-     * @param bool $resetState set to true to reset buffers and indents
      * @return string Markdown formatted output
      */
-    public function parseString($html, $resetState = false)
+    public function parseString($html)
     {
         /** TODO: custom markdown-extra options, e.g. titles & classes **/
         // <sup id="fnref:..."><a href"#fn..." rel="footnote">...</a></sup>
@@ -522,7 +521,7 @@ class ConverterExtra extends Converter
         // </footnotes>
         $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', array(&$this, '_makeFootnotes'), $html);
 
-        return parent::parseString($html, $resetState);
+        return parent::parseString($html);
     }
 
     /**

--- a/src/Markdownify/ConverterExtra.php
+++ b/src/Markdownify/ConverterExtra.php
@@ -497,9 +497,10 @@ class ConverterExtra extends Converter
      * parse a HTML string, clean up footnotes prior
      *
      * @param string $HTML input
+     * @param bool $resetState set to true to reset buffers and indents
      * @return string Markdown formatted output
      */
-    public function parseString($html)
+    public function parseString($html, $resetState = false)
     {
         /** TODO: custom markdown-extra options, e.g. titles & classes **/
         // <sup id="fnref:..."><a href"#fn..." rel="footnote">...</a></sup>
@@ -521,7 +522,7 @@ class ConverterExtra extends Converter
         // </footnotes>
         $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', array(&$this, '_makeFootnotes'), $html);
 
-        return parent::parseString($html);
+        return parent::parseString($html, $resetState);
     }
 
     /**

--- a/test/Test/Markdownify/ConverterTestCase.php
+++ b/test/Test/Markdownify/ConverterTestCase.php
@@ -478,4 +478,23 @@ end tell
 
         return $data;
     }
+
+    /* FIX STATE RESET
+     *************************************************************************/
+
+    public function testResetState()
+    {
+        // Broken (unclosed) tags cause properties (such as indents) to run onto subsequent strings,
+        $blockquote = 'Test blockquote <blockquote>Here it is';
+        $linebreaks = 'Test<br /><br />Linebreaks';
+
+        $converter = new Converter();
+        $bqOutput = $converter->parseString($blockquote);
+
+        $this->assertContains('>', $bqOutput);
+
+        $lbOutput = $converter->parseString($linebreaks);
+
+        $this->assertNotContains('>', $lbOutput);
+    }
 }


### PR DESCRIPTION
Issue reference: #19

The issue that I discovered is that I was using a single instance of the converter, injected into my constructor - but the actual parsing (call of `parseString`) was happening within a loop.

This meant that a large portion of the properties, such as indent, buffers etc were being carried over from one string to another.

 - String A would set the indent to `>` since it ends on a blockquote.
 - String B would then have `>` set to the indent at the beginning of its string (which is added during the `handleTag_br` method) regardless of whether it was using a blockquote or not.

There was no 'cleanup' of these properties between subsequent runs of `parseString` against the same instance. So here I added an optional variable to `parseString` to allow you to reset it's state. I defaulted this variable to false so that we don't break backward compatibility. 

There are conceivable situations where you would want subsequent runs of `parseString` to inherit the properties of a previous run (a single string split into multiple parts, for instance), so I kept this in mind with this edit.

