### PR TITLE
refactor: use php5.4 brackets syntax for arrays

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -34,7 +34,7 @@ class Converter
      *
      * @var array<string>
      */
-    protected $notConverted = array();
+    protected $notConverted = [];
 
     /**
      * skip conversion to markdown
@@ -82,67 +82,67 @@ class Converter
      *
      * @var array<string>
      */
-    protected $buffer = array();
+    protected $buffer = [];
 
     /**
      * stores current buffers
      *
      * @var array<string>
      */
-    protected $footnotes = array();
+    protected $footnotes = [];
 
     /**
      * tags with elements which can be handled by markdown
      *
      * @var array<string>
      */
-    protected $isMarkdownable = array(
-        'p' => array(),
-        'ul' => array(),
-        'ol' => array(),
-        'li' => array(),
-        'br' => array(),
-        'blockquote' => array(),
-        'code' => array(),
-        'pre' => array(),
-        'a' => array(
+    protected $isMarkdownable = [
+        'p' => [],
+        'ul' => [],
+        'ol' => [],
+        'li' => [],
+        'br' => [],
+        'blockquote' => [],
+        'code' => [],
+        'pre' => [],
+        'a' => [
             'href' => 'required',
             'title' => 'optional',
-        ),
-        'strong' => array(),
-        'b' => array(),
-        'em' => array(),
-        'i' => array(),
-        'img' => array(
+        ],
+        'strong' => [],
+        'b' => [],
+        'em' => [],
+        'i' => [],
+        'img' => [
             'src' => 'required',
             'alt' => 'optional',
             'title' => 'optional',
-        ),
-        'h1' => array(),
-        'h2' => array(),
-        'h3' => array(),
-        'h4' => array(),
-        'h5' => array(),
-        'h6' => array(),
-        'hr' => array(),
-    );
+        ],
+        'h1' => [],
+        'h2' => [],
+        'h3' => [],
+        'h4' => [],
+        'h5' => [],
+        'h6' => [],
+        'hr' => [],
+    ];
 
     /**
      * html tags to be ignored (contents will be parsed)
      *
      * @var array<string>
      */
-    protected $ignore = array(
+    protected $ignore = [
         'html',
         'body',
-    );
+    ];
 
     /**
      * html tags to be dropped (contents will not be parsed!)
      *
      * @var array<string>
      */
-    protected $drop = array(
+    protected $drop = [
         'script',
         'head',
         'style',
@@ -151,16 +151,16 @@ class Converter
         'object',
         'param',
         'iframe',
-    );
+    ];
 
     /**
      * html block tags that allow inline & block children
      *
      * @var array<string>
      */
-    protected $allowMixedChildren = array(
+    protected $allowMixedChildren = [
         'li'
-    );
+    ];
 
     /**
      * Markdown indents which could be wrapped
@@ -168,13 +168,13 @@ class Converter
      *
      * @var array<string>
      */
-    protected $wrappableIndents = array(
+    protected $wrappableIndents = [
         '\*   ', // ul
         '\d.  ', // ol
         '\d\d. ', // ol
         '> ', // blockquote
         '', // p
-    );
+    ];
 
     /**
      * list of chars which have to be escaped in normal text
@@ -184,7 +184,7 @@ class Converter
      *
      * TODO: what's with block chars / sequences at the beginning of a block?
      */
-    protected $escapeInText = array(
+    protected $escapeInText = [
         '\*\*([^*]+)\*\*' => '\*\*$1\*\*', // strong
         '\*([^*]+)\*' => '\*$1\*', // em
         '__(?! |_)(.+)(?!<_| )__' => '\_\_$1\_\_', // strong
@@ -194,7 +194,7 @@ class Converter
         '\[(.+)\](\s*\()' => '\[$1\]$2', // links: [text] (url) => [text\] (url)
         '\[(.+)\](\s*)\[(.*)\]' => '\[$1\]$2\[$3\]', // links: [text][id] => [text\][id\]
         '^#(#{0,5}) ' => '\#$1 ', // header
-    );
+    ];
 
     /**
      * wether last processed node was a block tag or not
@@ -220,7 +220,7 @@ class Converter
      *
      * @var array<array>
      */
-    protected $stack = array();
+    protected $stack = [];
 
     /**
      * current indentation
@@ -254,16 +254,16 @@ class Converter
         $this->parser->noTagsInCode = true;
 
         // we don't have to do this every time
-        $search = array();
-        $replace = array();
+        $search = [];
+        $replace = [];
         foreach ($this->escapeInText as $s => $r) {
             array_push($search, '@(?<!\\\)' . $s . '@U');
             array_push($replace, $r);
         }
-        $this->escapeInText = array(
+        $this->escapeInText = [
             'search' => $search,
             'replace' => $replace
-        );
+        ];
     }
 
     /**
@@ -399,7 +399,7 @@ class Converter
         $this->output = rtrim(str_replace('&amp;', '&', str_replace('&lt;', '<', str_replace('&gt;', '>', $this->output))));
         // end parsing, flush stacked tags
         $this->flushFootnotes();
-        $this->stack = array();
+        $this->stack = [];
     }
 
     /**
@@ -528,7 +528,7 @@ class Converter
             if ($this->parser->isBlockElement) {
                 if ($this->parser->isStartTag) {
                     // looks like ins or del are block elements now
-                    if (in_array($this->parent(), array('ins', 'del'))) {
+                    if (in_array($this->parent(), ['ins', 'del'])) {
                         $this->out("\n", true);
                         $this->indent('  ');
                     }
@@ -561,7 +561,7 @@ class Converter
                         $this->indent = $indent;
                     }
 
-                    if (in_array($this->parent(), array('ins', 'del'))) {
+                    if (in_array($this->parent(), ['ins', 'del'])) {
                         // ins or del was block element
                         $this->out("\n");
                         $this->indent('  ');
@@ -575,7 +575,7 @@ class Converter
             } else {
                 $this->out($this->parser->node);
             }
-            if (in_array($this->parser->tagName, array('code', 'pre'))) {
+            if (in_array($this->parser->tagName, ['code', 'pre'])) {
                 if ($this->parser->isStartTag) {
                     $this->buffer();
                 } else {
@@ -605,7 +605,7 @@ class Converter
                 $this->parser->node = preg_replace($this->escapeInText['search'], $this->escapeInText['replace'], $this->parser->node);
             }
         } else {
-            $this->parser->node = str_replace(array('&quot;', '&apos'), array('"', '\''), $this->parser->node);
+            $this->parser->node = str_replace(['&quot;', '&apos'], ['"', '\''], $this->parser->node);
         }
         $this->out($this->parser->node);
         $this->lastClosedTag = '';
@@ -884,11 +884,11 @@ class Converter
         }
         if (!$link_id) {
             $link_id = count($this->footnotes) + 1;
-            $tag = array(
+            $tag = [
                 'href' => $this->parser->tagAttributes['src'],
                 'linkID' => $link_id,
                 'title' => $this->parser->tagAttributes['title']
-            );
+            ];
             array_push($this->footnotes, $tag);
         }
         $out .= '[' . $link_id . ']';
@@ -1068,7 +1068,7 @@ class Converter
     protected function stack()
     {
         if (!isset($this->stack[$this->parser->tagName])) {
-            $this->stack[$this->parser->tagName] = array();
+            $this->stack[$this->parser->tagName] = [];
         }
         array_push($this->stack[$this->parser->tagName], $this->parser->tagAttributes);
     }
@@ -1306,7 +1306,7 @@ class Converter
         while (preg_match($regexp, $str, $matches)) {
             $string = $matches[0];
             $str = ltrim(substr($str, strlen($string)));
-            if (!$cut && isset($str[0]) && in_array($str[0], array('.', '!', ';', ':', '?', ','))) {
+            if (!$cut && isset($str[0]) && in_array($str[0], ['.', '!', ';', ':', '?', ','])) {
                 $string .= $str[0];
                 $str = ltrim(substr($str, 1));
             }
@@ -1387,14 +1387,14 @@ class Converter
      */
     protected function resetState()
     {
-        $this->notConverted = array();
+        $this->notConverted = [];
         $this->skipConversion = false;
-        $this->buffer = array();
+        $this->buffer = [];
         $this->indent = '';
-        $this->stack = array();
+        $this->stack = [];
         $this->lineBreaks = 0;
         $this->lastClosedTag = '';
         $this->lastWasBlockTag = false;
-        $this->footnotes = array();
+        $this->footnotes = [];
     }
 }

--- a/src/ConverterExtra.php
+++ b/src/ConverterExtra.php
@@ -12,7 +12,7 @@ class ConverterExtra extends Converter
      *
      * @var array
      */
-    protected $table = array();
+    protected $table = [];
 
     /**
      * current col
@@ -50,39 +50,39 @@ class ConverterExtra extends Converter
         $this->isMarkdownable['h6']['id'] = 'optional';
         $this->isMarkdownable['h6']['class'] = 'optional';
         // tables
-        $this->isMarkdownable['table'] = array();
-        $this->isMarkdownable['th'] = array(
+        $this->isMarkdownable['table'] = [];
+        $this->isMarkdownable['th'] = [
             'align' => 'optional',
-        );
-        $this->isMarkdownable['td'] = array(
+        ];
+        $this->isMarkdownable['td'] = [
             'align' => 'optional',
-        );
-        $this->isMarkdownable['tr'] = array();
+        ];
+        $this->isMarkdownable['tr'] = [];
         array_push($this->ignore, 'thead');
         array_push($this->ignore, 'tbody');
         array_push($this->ignore, 'tfoot');
         // definition lists
-        $this->isMarkdownable['dl'] = array();
-        $this->isMarkdownable['dd'] = array();
-        $this->isMarkdownable['dt'] = array();
+        $this->isMarkdownable['dl'] = [];
+        $this->isMarkdownable['dd'] = [];
+        $this->isMarkdownable['dt'] = [];
         // link class
         $this->isMarkdownable['a']['id'] = 'optional';
         $this->isMarkdownable['a']['class'] = 'optional';
         // footnotes
-        $this->isMarkdownable['fnref'] = array(
+        $this->isMarkdownable['fnref'] = [
             'target' => 'required',
-        );
-        $this->isMarkdownable['footnotes'] = array();
-        $this->isMarkdownable['fn'] = array(
+        ];
+        $this->isMarkdownable['footnotes'] = [];
+        $this->isMarkdownable['fn'] = [
             'name' => 'required',
-        );
+        ];
         $this->parser->blockElements['fnref'] = false;
         $this->parser->blockElements['fn'] = true;
         $this->parser->blockElements['footnotes'] = true;
         // abbr
-        $this->isMarkdownable['abbr'] = array(
+        $this->isMarkdownable['abbr'] = [
             'title' => 'required',
-        );
+        ];
         // build RegEx lookahead to decide wether table can pe parsed or not
         $inlineTags = array_keys($this->parser->blockElements, false);
         $colContents = '(?:[^<]|<(?:' . implode('|', $inlineTags) . '|[^a-z]))*';
@@ -195,7 +195,7 @@ class ConverterExtra extends Converter
      */
     protected function flushStacked_abbr()
     {
-        $out = array();
+        $out = [];
         foreach ($this->stack['abbr'] as $k => $tag) {
             if (!isset($tag['unstacked'])) {
                 array_push($out, ' *[' . $tag['text'] . ']: ' . $tag['title']);
@@ -225,7 +225,7 @@ class ConverterExtra extends Converter
                     preg_match_all('#<th(?:\s+align=("|\')(left|right|center)\1)?\s*>#si', $matches[0], $cols);
                     $regEx = '';
                     $i = 1;
-                    $aligns = array();
+                    $aligns = [];
                     foreach ($cols[2] as $align) {
                         $align = strtolower($align);
                         array_push($aligns, $align);
@@ -244,11 +244,11 @@ class ConverterExtra extends Converter
                     $regEx = sprintf($this->tableLookaheadBody, $regEx);
                     if (preg_match($regEx, $this->parser->html, $matches, null, strlen($matches[0]))) {
                         // this is a markdownable table tag!
-                        $this->table = array(
-                            'rows' => array(),
-                            'col_widths' => array(),
+                        $this->table = [
+                            'rows' => [],
+                            'col_widths' => [],
                             'aligns' => $aligns,
-                        );
+                        ];
                         $this->row = 0;
                     } else {
                         // non markdownable table
@@ -259,18 +259,18 @@ class ConverterExtra extends Converter
                     $this->handleTagToText();
                 }
             } else {
-                $this->table = array(
-                    'rows' => array(),
-                    'col_widths' => array(),
-                    'aligns' => array(),
-                );
+                $this->table = [
+                    'rows' => [],
+                    'col_widths' => [],
+                    'aligns' => [],
+                ];
                 $this->row = 0;
             }
         } else {
             // finally build the table in Markdown Extra syntax
-            $separator = array();
+            $separator = [];
             if (!isset($this->table['aligns'])) {
-                $this->table['aligns'] = array();
+                $this->table['aligns'] = [];
             }
             // seperator with correct align identifiers
             foreach ($this->table['aligns'] as $col => $align) {
@@ -294,9 +294,9 @@ class ConverterExtra extends Converter
             }
             $separator = '|' . implode('|', $separator) . '|';
 
-            $rows = array();
+            $rows = [];
             // add padding
-            array_walk_recursive($this->table['rows'], array(&$this, 'alignTdContent'));
+            array_walk_recursive($this->table['rows'], [&$this, 'alignTdContent']);
             $header = array_shift($this->table['rows']);
             array_push($rows, '| ' . implode(' | ', $header) . ' |');
             array_push($rows, $separator);
@@ -304,7 +304,7 @@ class ConverterExtra extends Converter
                 array_push($rows, '| ' . implode(' | ', $row) . ' |');
             }
             $this->out(implode("\n" . $this->indent, $rows));
-            $this->table = array();
+            $this->table = [];
             $this->setLineBreaks(2);
         }
     }
@@ -519,7 +519,7 @@ class ConverterExtra extends Converter
         //   <fn name="...">...</fn>
         //   ...
         // </footnotes>
-        $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', array(&$this, '_makeFootnotes'), $html);
+        $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', [&$this, '_makeFootnotes'], $html);
 
         return parent::parseString($html);
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -16,7 +16,7 @@ class Parser
      *
      * @var array<string>
      */
-    public $emptyTags = array(
+    public $emptyTags = [
         'br',
         'hr',
         'input',
@@ -25,7 +25,7 @@ class Parser
         'link',
         'meta',
         'param',
-    );
+    ];
 
     /**
      * tags with preformatted text
@@ -33,12 +33,12 @@ class Parser
      *
      * @var array<string>
      */
-    public $preformattedTags = array(
+    public $preformattedTags = [
         'script',
         'style',
         'pre',
         'code',
-    );
+    ];
 
     /**
      * supress HTML tags inside preformatted tags (see above)
@@ -140,7 +140,7 @@ class Parser
      *
      * @var array
      */
-    public $openTags = array();
+    public $openTags = [];
 
     /**
      * list of block elements
@@ -148,7 +148,7 @@ class Parser
      * @var array
      * TODO: what shall we do with <del> and <ins> ?!
      */
-    public $blockElements = array(
+    public $blockElements = [
         // tag name => <bool> is block
         // block elements
         'address' => true,
@@ -238,7 +238,7 @@ class Parser
         'tt' => false,
         'u' => false,
         'var' => false,
-    );
+    ];
 
     /**
      * get next node, set $this->html prior!
@@ -355,10 +355,10 @@ class Parser
         if (!isset(static::$a_ord)) {
             static::$a_ord = ord('a');
             static::$z_ord = ord('z');
-            static::$special_ords = array(
+            static::$special_ords = [
                 ord(':'), // for xml:lang
                 ord('-'), // for http-equiv
-            );
+            ];
         }
 
         $tagName = '';
@@ -397,7 +397,7 @@ class Parser
         // get tag attributes
         /** TODO: in html 4 attributes do not need to be quoted **/
         $isEmptyTag = false;
-        $attributes = array();
+        $attributes = [];
         $currAttrib = '';
         while (isset($this->html[$pos + 1])) {
             $pos++;
@@ -414,9 +414,9 @@ class Parser
             if (($pos_ord >= static::$a_ord && $pos_ord <= static::$z_ord) || in_array($pos_ord, static::$special_ords)) {
                 // attribute name
                 $currAttrib .= $this->html[$pos];
-            } elseif (in_array($this->html[$pos], array(' ', "\t", "\n"))) {
+            } elseif (in_array($this->html[$pos], [' ', "\t", "\n"])) {
                 // drop whitespace
-            } elseif (in_array($this->html[$pos] . $this->html[$pos + 1], array('="', "='"))) {
+            } elseif (in_array($this->html[$pos] . $this->html[$pos + 1], ['="', "='"])) {
                 // get attribute value
                 $pos++;
                 $await = $this->html[$pos]; // single or double quote

--- a/test/ConverterExtraTest.php
+++ b/test/ConverterExtraTest.php
@@ -35,13 +35,13 @@ class ConverterExtraTest extends ConverterTestCase
 
     public function providerHeadingConversion()
     {
-        $attributes = array(' id="idAttribute"', ' class=" class1  class2 "');
-        $data = array();
+        $attributes = [' id="idAttribute"', ' class=" class1  class2 "'];
+        $data = [];
         for ($i = 1; $i <= 6; $i++) {
-            $data[] = array($i, '', '');
-            $data[] = array($i, $attributes[0], ' {#idAttribute}');
-            $data[] = array($i, $attributes[1], ' {.class1.class2}');
-            $data[] = array($i, $attributes[0] . $attributes[1], ' {#idAttribute.class1.class2}');
+            $data[] = [$i, '', ''];
+            $data[] = [$i, $attributes[0], ' {#idAttribute}'];
+            $data[] = [$i, $attributes[1], ' {.class1.class2}'];
+            $data[] = [$i, $attributes[0] . $attributes[1], ' {#idAttribute.class1.class2}'];
         }
         return $data;
     }

--- a/test/ConverterTestCase.php
+++ b/test/ConverterTestCase.php
@@ -38,13 +38,13 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerHeadingConversion()
     {
-        $attributes = array(' id="idAttribute"', ' class=" class1  class2 "');
-        $data = array();
+        $attributes = [' id="idAttribute"', ' class=" class1  class2 "'];
+        $data = [];
         for ($i = 1; $i <= 6; $i++) {
-            $data[] = array($i, '');
-            $data[] = array($i, $attributes[0]);
-            $data[] = array($i, $attributes[1]);
-            $data[] = array($i, $attributes[0] . $attributes[1]);
+            $data[] = [$i, ''];
+            $data[] = [$i, $attributes[0]];
+            $data[] = [$i, $attributes[1]];
+            $data[] = [$i, $attributes[0] . $attributes[1]];
         }
         return $data;
     }
@@ -59,7 +59,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerHeadingConversionEscape()
     {
-        $data = array();
+        $data = [];
         $data['level1']['html'] = '# Heading 1';
         $data['level1']['md'] = '\# Heading 1';
         $data['level2']['html'] = '## Heading 2';
@@ -81,11 +81,11 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerAutoescapeConversion()
     {
-        return array(
-            array('AT&amp;T', 'AT&T'),
-            array('4 &lt; 5', '4 < 5'),
-            array('&copy;', '&copy;')
-        );
+        return [
+            ['AT&amp;T', 'AT&T'],
+            ['4 &lt; 5', '4 < 5'],
+            ['&copy;', '&copy;']
+        ];
     }
 
 
@@ -105,7 +105,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerKeepHTMLOption()
     {
-        $data = array();
+        $data = [];
 
         // Issue #16
         $data['image']['html'] = '<img title="a012.gif" src="http://images/problems/a012.gif" alt="a012.gif" width="374" height="204" />';
@@ -141,7 +141,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerBlockquoteConversion()
     {
-        $data = array();
+        $data = [];
         $data['simple']['html'] = '<blockquote>blockquoted text goes here</blockquote>';
         $data['simple']['md'] = '> blockquoted text goes here';
         $data['paragraphs']['html'] = '<blockquote><p>paragraph1</p><p>paragraph2</p></blockquote>';
@@ -169,7 +169,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerListConversion()
     {
-        $data = array();
+        $data = [];
         $data['ordered']['html'] = '<ol><li>Bird</li><li>McHale</li><li>Parish</li></ol>';
         $data['ordered']['md'] = '  1. Bird' . PHP_EOL
             . '  2. McHale' . PHP_EOL
@@ -242,7 +242,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
 
     public function providerCodeConversion()
     {
-        $data = array();
+        $data = [];
         $data['inline']['html'] = '<p>Use the <code>printf()</code> function.</p>';
         $data['inline']['md'] = 'Use the `printf()` function.';
         $data['inline-backtick']['html'] = '<p>A single backtick in a code span: <code>`</code></p>';
@@ -299,7 +299,7 @@ end tell
 
     public function providerLinkConversion()
     {
-        $data = array();
+        $data = [];
 
         // Link with href attribute
         $data['url']['html'] = '<p><a href="http://example.net/">This link</a> has no title attribute.</p>';
@@ -425,7 +425,7 @@ end tell
 
     public function providerEmphasisConversion()
     {
-        $data = array();
+        $data = [];
         $data['strong']['html'] = '<strong>double asterisks</strong>';
         $data['strong']['md'] = '**double asterisks**';
         $data['strong-escape']['html'] = '**double asterisks**';
@@ -456,7 +456,7 @@ end tell
 
     public function providerRulesConversion()
     {
-        $data = array();
+        $data = [];
         $data['hr']['html'] = '<hr>';
         $data['hr']['md'] = '* * *';
         $data['escape-']['html'] = '-----------------------------------';
@@ -482,7 +482,7 @@ end tell
 
     public function providerFixBreaks()
     {
-        $data = array();
+        $data = [];
         $data['break1']['html'] = "<strong>Hello,<br>How are you doing?</strong>";
         $data['break1']['md'] = "**Hello,  \nHow are you doing?**";
         $data['break2']['html'] = "<b>Hey,<br> How you're doing?</b><br><br><b>Sorry<br><br> You can't get through</b>";
@@ -505,7 +505,7 @@ end tell
 
     public function providerFixTagSpaces()
     {
-        $data = array();
+        $data = [];
         $data['strong']['html'] = "<p>This is<strong> strong</strong> text</p>";
         $data['strong']['md'] = "This is **strong** text";
         $data['em']['html'] = "<p>This is<em> italic </em>text</p>";


### PR DESCRIPTION
updated files to use php5.4+ brackets `[]` instead of older `array()`
syntax, also known as "short array syntax"
(see line 2 of new features here)[http://php.net/manual/en/migration54.new-features.php]

this resolves issue #26 