### PR TITLE
Change <> to [] around email address and url

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -788,15 +788,15 @@ class Converter
         }
 
         if ($buffer == $tag['href'] && empty($tag['title'])) {
-            // <http://example.com>
-            return '<' . $buffer . '>';
+            // [http://example.com]
+            return '[' . $buffer . ']';
         }
 
         $bufferDecoded = $this->decode(trim($buffer));
         if (substr($tag['href'], 0, 7) == 'mailto:' && 'mailto:' . $bufferDecoded == $tag['href']) {
             if (is_null($tag['title'])) {
-                // <mail@example.com>
-                return '<' . $bufferDecoded . '>';
+                // [mail@example.com]
+                return '[' . $bufferDecoded . ']';
             }
             // [mail@example.com][1]
             // ...

--- a/test/ConverterTestCase.php
+++ b/test/ConverterTestCase.php
@@ -117,7 +117,7 @@ class ConverterTestCase extends \PHPUnit_Framework_TestCase
         // Issue #23
         $data['target']['html'] = '<p>See <a href="https://github.com/quilljs/quill/issues/81" target="_blank">https://github.com/quilljs/quill/issues/81</a></p>';
         $data['target']['mdWithTag'] = 'See <a href="https://github.com/quilljs/quill/issues/81" target="_blank">https://github.com/quilljs/quill/issues/81</a>';
-        $data['target']['mdWithoutTag'] = 'See <https://github.com/quilljs/quill/issues/81>';
+        $data['target']['mdWithoutTag'] = 'See [https://github.com/quilljs/quill/issues/81]';
 
         // Issue #25
         $data['u']['html'] = '<span><u>Some text</u></span>';
@@ -347,7 +347,7 @@ end tell
 
         // Direct link
         $data['url-direct']['html'] = '<p><a href="http://example.com">http://example.com</a>.</p>';
-        $data['url-direct']['md'] = '<http://example.com>.';
+        $data['url-direct']['md'] = '[http://example.com].';
 
         // Link with href + title attributes
         $data['url-title']['html'] = '<p>This is <a href="http://example.com/" title="Title">an example</a> inline link.</p>';


### PR DESCRIPTION
After letting Markdownify do its job i also use strip_tags to remove any leftover html
strip_tags does not like to <> around urls and email addresses.
It's also possible to change <> to &lt;&gt; but I felt [] might be better.