### PR TITLE
Fix inline spacing fixer for empty tag

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -1360,7 +1360,7 @@ class Converter
      */
     protected function fixInlineElementSpacing()
     {
-        if ($this->parser->isStartTag) {
+        if ($this->parser->isStartTag && !$this->parser->isEmptyTag) {
             // move spaces after the start element to before the element
             if (preg_match('~^(\s+)~', $this->parser->html, $matches)) {
                 $this->out($matches[1]);

--- a/test/ConverterTestCase.php
+++ b/test/ConverterTestCase.php
@@ -486,7 +486,7 @@ end tell
         $data['break1']['html'] = "<strong>Hello,<br>How are you doing?</strong>";
         $data['break1']['md'] = "**Hello,  \nHow are you doing?**";
         $data['break2']['html'] = "<b>Hey,<br> How you're doing?</b><br><br><b>Sorry<br><br> You can't get through</b>";
-        $data['break2']['md'] = "**Hey,   \nHow you're doing?**  \n  \n**Sorry  \n   \nYou can't get through**";
+        $data['break2']['md'] = "**Hey,  \nHow you're doing?**  \n  \n**Sorry  \n  \nYou can't get through**";
 
         return $data;
     }


### PR DESCRIPTION
The `<br>` should not be considered as inline element, so the space should not move around.

By @SL-Gundam #32 
