### PR TITLE
Add aside as a block element

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -150,6 +150,7 @@ class Parser
         // tag name => <bool> is block
         // block elements
         'address' => true,
+        'aside' => true,
         'blockquote' => true,
         'center' => true,
         'del' => true,


### PR DESCRIPTION
Register <aside> as a block element - this element is used for documentation builders such as Slate within their Markdown templates