### PR TITLE
Fixed Converter to work with PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install
 php:
+  - 7.3
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -344,7 +344,7 @@ class Converter
                     if ($this->skipConversion) {
                         $this->isMarkdownable(); // update notConverted
                         $this->handleTagToText();
-                        continue;
+                        break;
                     }
 
                     // block elements


### PR DESCRIPTION
Fixed failing tests in PHP7.3: "PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/Markdownify/src/Converter.php on line 347
PHP Stack trace:
PHP   1. {main}() /var/www/Markdownify/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /var/www/Markdownify/vendor/phpunit/phpunit/phpunit:52
PHP   3. PHPUnit_TextUI_Command->run() /var/www/Markdownify/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->getTest() /var/www/Markdownify/vendor/phpunit/phpunit/src/TextUI/Command.php:122
PHP   5. PHPUnit_Framework_TestSuite->__construct() /var/www/Markdownify/vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:99
PHP   6. PHPUnit_Framework_TestSuite->addTestMethod() /var/www/Markdownify/vendor/phpunit/phpunit/src/Framework/TestSuite.php:170
PHP   7. PHPUnit_Framework_TestSuite::createTest() /var/www/Markdownify/vendor/phpunit/phpunit/src/Framework/TestSuite.php:855
PHP   8. PHPUnit_Util_Test::getProvidedData() /var/www/Markdownify/vendor/phpunit/phpunit/src/Framework/TestSuite.php:455
PHP   9. PHPUnit_Util_Test::getDataFromDataProviderAnnotation() /var/www/Markdownify/vendor/phpunit/phpunit/src/Util/Test.php:374
PHP  10. ReflectionMethod->invoke() /var/www/Markdownify/vendor/phpunit/phpunit/src/Util/Test.php:447
PHP  11. Test\Markdownify\ConverterTest->providerLinkConversion() /var/www/Markdownify/vendor/phpunit/phpunit/src/Util/Test.php:447
PHP  12. spl_autoload_call() /var/www/Markdownify/test/ConverterTestCase.php:322
PHP  13. Composer\Autoload\ClassLoader->loadClass() /var/www/Markdownify/test/ConverterTestCase.php:322
PHP  14. Composer\Autoload\includeFile() /var/www/Markdownify/vendor/composer/ClassLoader.php:322
PHPUnit 4.8.36 by Sebastian Bergmann and contributors."