### PR TITLE
Addressed PHP 8.3 deprecation notices

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -228,6 +228,11 @@ class Converter
     protected $indent = '';
 
     /**
+     * @var string
+     */
+    private string $previousIndent = '';
+
+    /**
      * constructor, set options, setup parser
      *
      * @param int $linkPosition define the position of links
@@ -534,8 +539,7 @@ class Converter
                     // don't indent inside <pre> tags
                     if ($this->parser->tagName == 'pre') {
                         $this->out($this->parser->node);
-                        static $indent;
-                        $indent = $this->indent;
+                        $this->previousIndent = $this->indent;
                         $this->indent = '';
                     } else {
                         $this->out($this->parser->node . "\n" . $this->indent);
@@ -556,8 +560,7 @@ class Converter
                     } else {
                         // reset indentation
                         $this->out($this->parser->node);
-                        static $indent;
-                        $this->indent = $indent;
+                        $this->indent = $this->previousIndent;
                     }
 
                     if (in_array($this->parent(), ['ins', 'del'])) {

--- a/src/ConverterExtra.php
+++ b/src/ConverterExtra.php
@@ -27,6 +27,21 @@ class ConverterExtra extends Converter
     protected $row = 0;
 
     /**
+     * @var string
+     */
+    private $tableLookaheadHeader = '';
+
+    /**
+     * @var string
+     */
+    private $tdSubstitute = '';
+
+    /**
+     * @var string
+     */
+    private $tableLookaheadBody = '';
+
+    /**
      * constructor, see Markdownify::Markdownify() for more information
      */
     public function __construct($linksAfterEachParagraph = self::LINK_AFTER_CONTENT, $bodyWidth = MDFY_BODYWIDTH, $keepHTML = MDFY_KEEPHTML)


### PR DESCRIPTION
This PR incorporates the work in https://github.com/Elephant418/Markdownify/pull/48, and adds additional properties to fix the deprecation notices since PHP 8.3:

```
[PHP Decprecated] Creation of dynamic property Markdownify\ConverterExtra::$tableLookaheadHeader is deprecated in /vendor/pixel418/markdownify/src/ConverterExtra.php:87
[PHP Decprecated] Creation of dynamic property Markdownify\ConverterExtra::$tdSubstitute is deprecated in /vendor/pixel418/markdownify/src/ConverterExtra.php:96
[PHP Decprecated] Creation of dynamic property Markdownify\ConverterExtra::$tableLookaheadBody is deprecated in /vendor/pixel418/markdownify/src/ConverterExtra.php:98
 ```

I have not been able to test via the included tests, as PHPUnit is still at v4 and this is no longer compatible with PHP 8.3 (and I don't have the time to upgrade it in this PR), however this is a minimal change so it should not have any new bugs.

